### PR TITLE
The vuejs form should apply for both edit and new page

### DIFF
--- a/app/assets/javascripts/bookmark-vue.js
+++ b/app/assets/javascripts/bookmark-vue.js
@@ -1,7 +1,7 @@
 function loadBookmarkVue() {
-  if ($("#new_bookmark").length) {
+  if ($("#bookmark_form").length) {
     new Vue({
-      el: "#new_bookmark",
+      el: "#bookmark_form",
       data: {
         title: null,
         url: null,

--- a/app/views/bookmarks/_form.html.haml
+++ b/app/views/bookmarks/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @bookmark do |f|
+= form_for @bookmark, html: { id: 'bookmark_form' } do |f|
   - if @bookmark.errors.any?
     #error_explanation
       %h2= "#{pluralize(@bookmark.errors.count, "error")} prohibited this bookmark from being saved:"


### PR DESCRIPTION
Currently the Vue component only apply for new bookmark page. When you visit edit page you will see the page is broken and it doesn't load page info when you edit the url(see attachment below).

![image](https://cloud.githubusercontent.com/assets/23716494/20737971/820185ca-b6e2-11e6-9570-883269e04871.png)

I made the change to make the edit bookmark page has same behavior to new bookmark page
- Create a div cover all element under form
- Vue will added when see the new operator
